### PR TITLE
Should render empty strings like ES6 does

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,6 @@ function templateFn (str) {
     if (prop && prop.indexOf('.') !== -1) {
       return get(data, prop, true)
     }
-    return data[prop] || prop
+    return typeof data[prop] !== 'undefined' ? data[prop] : ''
   })
 }

--- a/test.js
+++ b/test.js
@@ -60,3 +60,9 @@ test('should be able to escape dot property paths', function (done) {
   test.strictEqual(actual, 'foo ~BAR~ baz')
   done()
 })
+
+test('should render empty strings correctly', function (done) {
+  var actual = template.render('hello ${name}!', {name: ''})
+  test.strictEqual(actual, 'hello !')
+  done()
+})


### PR DESCRIPTION
When a variable referenced as `${foo}` is an empty string, ES6 renders an empty string but es6-template renders the name inside the expression.

```
node
> es6template = require('es6-template')
{ [Function: es6template] render: [Function: render], compile: [Function: compile] }
> es6template.render('Hello ${name}', { name: ''})
'Hello name'
> es6template.render('Hello ${name}', { name: 'foo'})
'Hello foo'
```

```
babel-node
> var name = ''
'use strict'
> `Hello ${name}`
'Hello '
> name = 'foo'
'foo'
> `Hello ${name}`
'Hello foo'
```
