### PR TITLE
Update try-catch-callback to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "gana": "^1.1.1",
-    "try-catch-callback": "^1.0.2"
+    "try-catch-callback": "^2.0.1"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
This PR updates the [try-catch-callback](https://github.com/hybridables/try-catch-callback/) dependency.

  - its usage in this project was compatible with new code in 2.0.1
  - see [its CHANGELOG](https://github.com/hybridables/try-catch-callback/blob/master/CHANGELOG.md)